### PR TITLE
Remove invalid param in documentation

### DIFF
--- a/core-iconset.html
+++ b/core-iconset.html
@@ -212,7 +212,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
        * @param {Element} element The element to which the background is
        * applied.
        * @param {String|Number} icon The name or index of the icon to apply.
-       * @param {String} theme (optional) The name of the theme for the icon.
        * @param {Number} scale (optional, defaults to 1) A scaling factor 
        * with which the icon can be magnified.
        * @return {Element} The icon element.


### PR DESCRIPTION
I assume this was deprecated?
